### PR TITLE
Add VM monitoring helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ the "Test" and "Deliver" stages of your Pipeline.
 
 ## VM Monitor Script
 
-This repository also contains a small example for monitoring virtual machines on a Linux host.
-The files in `vm-monitor` provide a `vm_watch.sh` script and the corresponding systemd
-service and timer units.
+This repository also contains a small example for monitoring VirtualBox virtual
+machines on a Linux host. The files in `vm-monitor` provide a `vm_watch.sh`
+script (which uses `VBoxManage`) and the corresponding systemd service and timer
+units.
 
 1. Copy `vm-monitor/vm_watch.sh` to `/usr/local/bin/` and make it executable:
    ```bash
@@ -34,5 +35,6 @@ service and timer units.
    sudo systemctl enable --now vm-watch.timer
    ```
 
-With this setup the script checks a list of VMs every five minutes and starts any that
-are found powered off.
+Edit the `VMS` array inside `vm_watch.sh` with the names of your VirtualBox
+VMs. With this setup the script checks these VMs every five minutes and starts
+any that are found powered off.

--- a/README.md
+++ b/README.md
@@ -12,3 +12,27 @@ The `jenkins` directory contains an example of the `Jenkinsfile` (i.e. Pipeline)
 you'll be creating yourself during the tutorial and the `scripts` subdirectory
 contains shell scripts with commands that are executed when Jenkins processes
 the "Test" and "Deliver" stages of your Pipeline.
+
+## VM Monitor Script
+
+This repository also contains a small example for monitoring virtual machines on a Linux host.
+The files in `vm-monitor` provide a `vm_watch.sh` script and the corresponding systemd
+service and timer units.
+
+1. Copy `vm-monitor/vm_watch.sh` to `/usr/local/bin/` and make it executable:
+   ```bash
+   sudo install -m 755 vm-monitor/vm_watch.sh /usr/local/bin/vm_watch.sh
+   ```
+2. Copy the service and timer files to `/etc/systemd/system/`:
+   ```bash
+   sudo cp vm-monitor/vm-watch.service /etc/systemd/system/
+   sudo cp vm-monitor/vm-watch.timer /etc/systemd/system/
+   ```
+3. Reload systemd and enable the timer:
+   ```bash
+   sudo systemctl daemon-reload
+   sudo systemctl enable --now vm-watch.timer
+   ```
+
+With this setup the script checks a list of VMs every five minutes and starts any that
+are found powered off.

--- a/vm-monitor/vm-watch.service
+++ b/vm-monitor/vm-watch.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Servicio de monitoreo de VMs
-After=network.target libvirtd.service
+After=network.target vboxdrv.service
 
 [Service]
 Type=simple

--- a/vm-monitor/vm-watch.service
+++ b/vm-monitor/vm-watch.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Servicio de monitoreo de VMs
+After=network.target libvirtd.service
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/vm_watch.sh
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/vm-monitor/vm-watch.timer
+++ b/vm-monitor/vm-watch.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Ejecucion periodica de vm-watch.service
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=5min
+
+[Install]
+WantedBy=timers.target

--- a/vm-monitor/vm_watch.sh
+++ b/vm-monitor/vm_watch.sh
@@ -3,8 +3,8 @@
 VMS=("vm1" "vm2" "vm3")
 
 for VM in "${VMS[@]}"; do
-    if ! virsh domstate "$VM" | grep -q "running"; then
+    if ! VBoxManage showvminfo "$VM" --machinereadable | grep -q 'VMState="running"'; then
         echo "$(date): $VM no esta corriendo. Iniciando..." >> /var/log/vm_watch.log
-        virsh start "$VM"
+        VBoxManage startvm "$VM" --type headless
     fi
 done

--- a/vm-monitor/vm_watch.sh
+++ b/vm-monitor/vm_watch.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Simple script to ensure specific virtual machines stay running
+VMS=("vm1" "vm2" "vm3")
+
+for VM in "${VMS[@]}"; do
+    if ! virsh domstate "$VM" | grep -q "running"; then
+        echo "$(date): $VM no esta corriendo. Iniciando..." >> /var/log/vm_watch.log
+        virsh start "$VM"
+    fi
+done


### PR DESCRIPTION
## Summary
- add `vm_watch.sh` example script for ensuring VMs stay powered on
- include systemd service and timer units
- document how to install them

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f5f41a21c8321b1f8ddced25b38c5